### PR TITLE
ci(github-actions: use Docker image to package build tools

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,24 +16,17 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
+    container: conanio/gcc11
 
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Get GCC
-      uses: egor-tensin/setup-gcc@v1
-      with:
-        version: 11
-
-    - name: Get Conan
-      uses: turtlebrowser/get-conan@v1.0
-
     - name: Setup Conan Profile
       run: |
         conan profile new --detect default
         conan profile update settings.compiler.libcxx=libstdc++11 default
         conan profile update settings.build_type=${{env.BUILD_TYPE}} default
         conan profile update env.CONAN_RUN_TESTS=True default
+
+    - uses: actions/checkout@v2
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
Replace the use of dedicated actions to fetch build tools with a single Docker image containing the requisite tools.