### PR TITLE
feat/exfs-utility-pair/constructors

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -40,6 +40,7 @@ class ArcheConan (ConanFile):
     def build_requirements (self):
         if self._run_tests:
             self.test_requires('catch2/2.13.7')
+            self.test_requires('trompeloeil/42')
 
     def config_options (self):
         if self.settings.arch == 'avr':

--- a/include/exfs/testing/Regular_Object.hpp
+++ b/include/exfs/testing/Regular_Object.hpp
@@ -1,0 +1,174 @@
+#ifndef EXFS_TESTING_REGULAR_OBJECT_HPP_
+#define EXFS_TESTING_REGULAR_OBJECT_HPP_
+
+#include <cstddef>
+
+#include <compare>
+#include <concepts>
+#include <memory>
+
+#include <trompeloeil.hpp>
+
+namespace exfs::testing {
+/**
+ * Type used as a stand-in for a [C++ Concept] "regular" type.
+ *
+ * This type is inteded to be used to test templates with very generic
+ * requirements, such as containers. It conforms to the @c std::regular
+ * concept. A regular type is one that can be copied, moved, swapped, default
+ * constructed, and is equality comparable.
+ *
+ * Each instance has two member fields: (1) a unique ID assigned to each
+ * instance and (2) an @c int representing the "data identity" of the object.
+ * The data field is copied in copy/move constructors, changed through object
+ * assignment, and swapped in swap operations but the ID field remains constant
+ * for the lifetime of the object.
+ *
+ * The class must be initialized at the start of each test. The @c initialize
+ * function returns a @c Mock object that is used to track constructor and
+ * other function calls. See below for more details.
+ */
+class Regular_Object {
+  public:
+    /**
+     * Mock type used to track function calls of all instances of @c
+     * Regular_Object.
+     */
+    struct Mock {
+        MAKE_MOCK2(default_construct, void(int, int));
+        MAKE_MOCK2(copy_construct, void(int, int));
+        MAKE_MOCK2(move_construct, void(int, int));
+        MAKE_MOCK4(copy_assign, void(int, int, int, int));
+        MAKE_MOCK4(move_assign, void(int, int, int, int));
+        MAKE_MOCK2(destruct, void(int, int));
+    };
+
+    /**
+     * Set up the class for use in a test.
+     *
+     * Must be called at the start of each test case and does the following:
+     *   - reset the ID sequence
+     *   - create a @c Mock object
+     *
+     * @note The class holds onto a reference to the @c Mock object via a @c
+     *     std::weak_ptr. The caller must hold onto the returned @c
+     *     std::shared_ptr for as long as they want the @c Mock object to live.
+     *
+     * @returns A shared pointer that is the sole owner of a new @c Mock
+     *     object.
+     */
+    static std::shared_ptr<Mock> initialize () {
+        next_id_ = 0;
+        auto mock_obj = std::make_shared<Mock>();
+        mock_obj_weak_ = mock_obj;
+        return mock_obj;
+    }
+
+    /**
+     * Default construct a new object. The data value is equal to the new ID.
+     */
+    Regular_Object () : id_{next_id_++}, data_{id_} {
+        mock_obj_()->default_construct(id_, data_);
+    }
+
+    /**
+     * Copy construct a new object. The new object will have it's own ID but
+     * will share the same data value as @p other_obj.
+     */
+    Regular_Object (Regular_Object const& other_obj)
+      : id_{next_id_++},
+        data_{other_obj.data_}
+    {
+        mock_obj_()->copy_construct(id_, data_);
+    }
+
+    /**
+     * "Move" construct a new object. The new object will have it's own ID but
+     * will share the same data value as @p other_obj.
+     */
+    Regular_Object (Regular_Object&& other_obj) noexcept
+      : id_{next_id_++},
+        data_{other_obj.data_}
+    {
+        mock_obj_()->move_construct(id_, data_);
+    }
+
+    /**
+     * "Destroy" the object. Nothing is actually cleaned up. This just logs the
+     *  destructor call with the static @c Mock object.
+     */
+    ~Regular_Object () {
+        mock_obj_()->destruct(id_, data_);
+    }
+
+    /**
+     * Copy assign from @p other_obj. This object will take the data value of @p
+     * other_obj but retain it's own ID.
+     */
+    Regular_Object& operator = (Regular_Object const& other_obj) {
+        mock_obj_()->copy_assign(id_, data_, other_obj.id_, other_obj.data_);
+        data_ = other_obj.data_;
+
+        return *this;
+    }
+
+    /**
+     * "Move" assign from @p other_obj. This object will take the data value
+     * of @p other_obj but retain it's own ID.
+     */
+    Regular_Object& operator = (Regular_Object&& other_obj) {
+        mock_obj_()->move_assign(id_, data_, other_obj.id_, other_obj.data_);
+        data_ = other_obj.data_;
+
+        return *this;
+    }
+
+    /**
+     * The ID of this instance. This is unique among all instances created since
+     * the last call to @c initialize().
+     */
+    int id () const { return id_; }
+
+    /**
+     * Value representing the "data identity" of the object.
+     */
+    int data () const { return data_; }
+
+  private:
+    static inline int next_id_ = 0;
+
+    static inline std::weak_ptr<Mock> mock_obj_weak_;
+
+    int id_;
+    int data_;
+
+    /**
+     * Helper function to get a @c std::shared_ptr from the static @c Mock
+     * object.
+     */
+    static std::shared_ptr<Mock> mock_obj_ () {
+        return std::shared_ptr{mock_obj_weak_};
+    }
+};
+
+/**
+ * Compare two @c Regular_Object instances for semantic equality.
+ * @return @c true if they have the same data, else @c false.
+ */
+bool operator == (Regular_Object const& obj_a, Regular_Object const& obj_b) {
+    // return std::compare_three_way{}(obj_a.data(), obj_b.data());
+    return obj_a.data() == obj_b.data();
+}
+
+/**
+ * Compare two @c Regular_Object instances for semantic inequality.
+ * @return @c true if they have different data, else @c false.
+ */
+bool operator != (Regular_Object const& obj_a, Regular_Object const& obj_b) {
+    return obj_a.data() != obj_b.data();
+}
+
+static_assert(std::regular<Regular_Object>);
+}  // namespace exfs::testing
+
+#endif  // EXFS_TESTING_REGULAR_OBJECT_HPP_

--- a/include/exfs/utility/pair.hpp
+++ b/include/exfs/utility/pair.hpp
@@ -1,0 +1,17 @@
+#ifndef EXFS_UTILITY_PAIR_HPP_
+#define EXFS_UTILITY_PAIR_HPP_
+
+namespace exfs::utility {
+/*!
+    A @c pair is a class template that provides a way to store two heterogeneous
+    objects as a single unit. A pair is a specific case of a @c tuple with two
+    elements.
+ */
+template <typename T1, typename T2>
+struct pair {
+    using first_type = T1;
+    using second_type = T2;
+};
+}  // namespace exfs::utility
+
+#endif  // EXFS_UTILITY_PAIR_HPP_

--- a/include/exfs/utility/pair.hpp
+++ b/include/exfs/utility/pair.hpp
@@ -1,6 +1,11 @@
 #ifndef EXFS_UTILITY_PAIR_HPP_
 #define EXFS_UTILITY_PAIR_HPP_
 
+#include <concepts>
+#include <type_traits>
+
+#include "exfs/utility/functions.hpp"
+
 namespace exfs::utility {
 /*!
     A @c pair is a class template that provides a way to store two heterogeneous
@@ -11,6 +16,65 @@ template <typename T1, typename T2>
 struct pair {
     using first_type = T1;
     using second_type = T2;
+
+    /*!
+        Data stored by this @c pair type.
+     */
+    first_type first{};
+    second_type second{};
+
+    /**
+     * Default constructor. Value-initializes both elements of the pair, @c
+     * first and @c second.
+     */
+    constexpr pair () {}
+
+    /**
+     * Copy constructor is defaulted and is @c constexpr if copying of both
+     * elements satisfies the requirements on constexpr functions.
+     */
+    constexpr pair (pair const&) = default;
+
+    /**
+     * Move constructor is defaulted and is @c constexpr if moving of both
+     * elements satisfies the requirements on constexpr functions.
+     */
+    constexpr pair (pair&&) = default;
+
+    /**
+     * Initializes @c first with @p x and @c second with @p y. The arguments are
+     * forwarded to constructors for each element.
+     */
+    template <typename U1 = T1, typename U2 = T2>
+    constexpr pair (U1&& x, U2&& y)
+      : first{exfs::forward<U1>(x)},
+        second{exfs::forward<U2>(y)}
+    {}
+
+    /**
+     * Initialize @c first with @p other.first and @c second with @p
+     * other.second. This constructor participates in overload resolution if @c
+     * other is not the same type as the constructed object.
+     */
+    template <typename U1, typename U2>
+    requires (not std::same_as<pair<U1, T2>, pair>)
+    constexpr pair (pair<U1, U2> const& other)
+      : first{other.first},
+        second{other.second}
+    {}
+
+    /**
+     * Initialize @c first with @p other.first and @c second with @p
+     * other.second. The arguments are forwarded to constructors for each
+     * element. This constructor participates in overload resolution if @c
+     * other is not the same type as the constructed object.
+     */
+    template <typename U1, typename U2>
+    requires (not std::same_as<pair<U1, T2>, pair>)
+    constexpr pair (pair<U1, U2>&& other)
+      : first{exfs::forward<U1>(other.first)},
+        second{exfs::forward<U2>(other.second)}
+    {}
 };
 }  // namespace exfs::utility
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@
 find_package(Catch2 REQUIRED)
 include(Catch)
 
+find_package(trompeloeil REQUIRED)
+
 file(GLOB_RECURSE test_files CONFIGURE_DEPENDS "test_*.cpp")
 
 add_executable(unit_test
@@ -17,6 +19,7 @@ target_compile_options(unit_test
 target_link_libraries(unit_test
     # 3rd-party
     Catch2::Catch2
+    trompeloeil::trompeloeil
 
     # local
     ${PROJECT_NAME}

--- a/tests/exfs/utility/test_functions.cpp
+++ b/tests/exfs/utility/test_functions.cpp
@@ -1,6 +1,7 @@
 #include "exfs/utility/functions.hpp"
 
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include <catch2/catch.hpp>

--- a/tests/exfs/utility/test_pair.cpp
+++ b/tests/exfs/utility/test_pair.cpp
@@ -1,0 +1,26 @@
+#include "exfs/utility/pair.hpp"
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include <catch2/catch.hpp>
+
+TEMPLATE_PRODUCT_TEST_CASE(
+    "exfs::utility::pair - member aliases",
+    "[unit][std-parity][utility-pair]",
+    (std::pair, exfs::utility::pair),
+    ((int const, std::string&))
+) {
+    GIVEN("a concrete pair type to test") {
+        using Pair = TestType;
+
+        THEN("the first type is a `int&`") {
+            CHECK(std::is_same_v<typename Pair::first_type, int const>);
+        }
+
+        THEN("the second type is a `std::string const`") {
+            CHECK(std::is_same_v<typename Pair::second_type, std::string&>);
+        }
+    }
+}

--- a/tests/exfs/utility/test_pair.cpp
+++ b/tests/exfs/utility/test_pair.cpp
@@ -1,26 +1,261 @@
 #include "exfs/utility/pair.hpp"
 
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
 #include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
 
-TEMPLATE_PRODUCT_TEST_CASE(
+#include "exfs/testing/Regular_Object.hpp"
+
+TEMPLATE_TEST_CASE(
     "exfs::utility::pair - member aliases",
     "[unit][std-parity][utility-pair]",
-    (std::pair, exfs::utility::pair),
-    ((int const, std::string&))
+    (std::pair<int const&, std::string>),
+    (exfs::utility::pair<int const&, std::string>)
 ) {
     GIVEN("a concrete pair type to test") {
         using Pair = TestType;
 
-        THEN("the first type is a `int&`") {
-            CHECK(std::is_same_v<typename Pair::first_type, int const>);
+        THEN("the first type is a `int const&`") {
+            CHECK(std::is_same_v<typename Pair::first_type, int const&>);
         }
 
-        THEN("the second type is a `std::string const`") {
-            CHECK(std::is_same_v<typename Pair::second_type, std::string&>);
+        THEN("the second type is a `std::string`") {
+            CHECK(std::is_same_v<typename Pair::second_type, std::string>);
+        }
+    }
+}
+
+template <typename T_Old_Full, typename... T_New_Inner>
+struct rebind;
+
+template <typename T_Old_Full, typename... T_New_Inner>
+using rebind_t = typename rebind<T_Old_Full, T_New_Inner...>::type;
+
+template <
+    template <typename...> typename T_Outer,
+    typename... T_New_Inner,
+    typename... T_Old_Inner
+>
+struct rebind<T_Outer<T_Old_Inner...>, T_New_Inner...> {
+    using type = T_Outer<T_New_Inner...>;
+};
+
+
+using exfs::testing::Regular_Object;
+
+TEMPLATE_TEST_CASE(
+    "exfs::utility::pair - constructors",
+    "[unit][std-parity][utility-pair]",
+    (std::pair<Regular_Object, Regular_Object const&>),
+    (exfs::utility::pair<Regular_Object, Regular_Object const&>)
+) {
+    using Pair = TestType;
+    using trompeloeil::_;
+    auto mock_obj = Regular_Object::initialize();
+
+    // Allow arbitrary destruction.
+    ALLOW_CALL(*mock_obj, destruct(_, _));
+
+    GIVEN("constituent values") {
+        REQUIRE_CALL(*mock_obj, default_construct(0, 0));
+        REQUIRE_CALL(*mock_obj, default_construct(1, 1));
+
+        Regular_Object obj_0;
+        Regular_Object obj_1;
+
+        WHEN("constructed with two value types") {
+            // Object-0 is copied. Object-1 is not.
+            REQUIRE_CALL(*mock_obj, copy_construct(2, 0));
+
+            Pair pair{obj_0, obj_1};
+
+            THEN("the types of member variables match the member aliases") {
+                CHECK(std::is_same_v<decltype(pair.first), Regular_Object>);
+                CHECK(std::is_same_v<
+                    decltype(pair.second),
+                    Regular_Object const&
+                >);
+            }
+
+            THEN("the first value is equal to the copied value") {
+                CHECK(pair.first == obj_0);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(pair.second == obj_1);
+                CHECK(&pair.second == &obj_1);
+            }
+        }
+
+        WHEN("constructed by moving into the first (value) type") {
+            // Object-0 is moved. Object-1 is not.
+            REQUIRE_CALL(*mock_obj, move_construct(2, 0));
+
+            Pair pair{std::move(obj_0), obj_1};
+
+            THEN("the first value is equal to the copied value") {
+                CHECK(pair.first == obj_0);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(pair.second == obj_1);
+                CHECK(&pair.second == &obj_1);
+            }
+        }
+
+        WHEN("constructed by moving into the second (reference) type") {
+            // Object-0 is copied. Object-1 is not.
+            REQUIRE_CALL(*mock_obj, copy_construct(2, 0));
+
+            Pair pair{obj_0, std::move(obj_1)};
+
+            THEN("the first value is equal to the copied value") {
+                CHECK(pair.first == obj_0);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(pair.second == obj_1);
+                CHECK(&pair.second == &obj_1);
+            }
+        }
+    }
+
+    GIVEN("a source pair of the same type") {
+        REQUIRE_CALL(*mock_obj, default_construct(0, 0));
+        REQUIRE_CALL(*mock_obj, default_construct(1, 1));
+        REQUIRE_CALL(*mock_obj, move_construct(2, 1));
+
+        // Referenced object.
+        Regular_Object obj_0;
+
+        Pair src_pair{Regular_Object{}, obj_0};
+
+        WHEN("constructed with lvalue of existing pair") {
+            // The first item (object-1, a value) is copied. The second
+            // (reference) item (object-0, a reference) is not.
+            REQUIRE_CALL(*mock_obj, copy_construct(3, 1));
+
+            Pair result_pair{src_pair};
+
+            THEN("the first value is equal to the copied value") {
+                CHECK(result_pair.first == src_pair.first);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(result_pair.second == obj_0);
+                CHECK(&result_pair.second == &obj_0);
+            }
+        }
+
+        WHEN("constructed with rvalue of existing pair") {
+            // The first item (object-1, a value) is moved. The second
+            // (reference) item (object-0, a reference) is not.
+            REQUIRE_CALL(*mock_obj, move_construct(3, 1));
+
+            Pair result_pair{std::move(src_pair)};
+
+            THEN("the first value is equal to the moved value") {
+                CHECK(result_pair.first == src_pair.first);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(result_pair.second == obj_0);
+                CHECK(&result_pair.second == &obj_0);
+            }
+        }
+    }
+
+    GIVEN("a source pair of lvalue references") {
+        REQUIRE_CALL(*mock_obj, default_construct(0, 0));
+        REQUIRE_CALL(*mock_obj, default_construct(1, 1));
+
+        Regular_Object obj_0;
+        Regular_Object obj_1;
+
+        using Src_Pair = rebind_t<Pair, Regular_Object&, Regular_Object&>;
+
+        Src_Pair src_pair{obj_0, obj_1};
+
+        WHEN("constructed with lvalue of existing pair") {
+            // Object-0 is copied. Object-1 is not.
+            REQUIRE_CALL(*mock_obj, copy_construct(2, 0));
+
+            Pair result_pair{src_pair};
+
+            THEN("the first value is equal to the copied value") {
+                CHECK(result_pair.first == src_pair.first);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(result_pair.second == src_pair.second);
+                CHECK(&result_pair.second == &src_pair.second);
+            }
+        }
+
+        WHEN("constructed with rvalue of existing pair") {
+            // Object-0 is copied due to reference collapsing rules. Object-1,
+            // as a reference, is neither copied nor moved.
+            REQUIRE_CALL(*mock_obj, copy_construct(2, 0));
+
+            Pair result_pair{std::move(src_pair)};
+
+            THEN("the first value is equal to the moved value") {
+                CHECK(result_pair.first == src_pair.first);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(result_pair.second == src_pair.second);
+                CHECK(&result_pair.second == &src_pair.second);
+            }
+        }
+    }
+
+    GIVEN("a source pair of rvalue references") {
+        REQUIRE_CALL(*mock_obj, default_construct(0, 0));
+        REQUIRE_CALL(*mock_obj, default_construct(1, 1));
+
+        Regular_Object obj_0;
+        Regular_Object obj_1;
+
+        using Src_Pair = rebind_t<Pair, Regular_Object&&, Regular_Object&&>;
+
+        Src_Pair src_pair{std::move(obj_0), std::move(obj_1)};
+
+        WHEN("constructed with lvalue of existing pair") {
+            // Object-0 is copied. Object-1 is not
+            REQUIRE_CALL(*mock_obj, copy_construct(2, 0));
+
+            Pair result_pair{src_pair};
+
+            THEN("the first value is equal to the copied value") {
+                CHECK(result_pair.first == src_pair.first);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(result_pair.second == src_pair.second);
+                CHECK(&result_pair.second == &src_pair.second);
+            }
+        }
+
+        WHEN("constructed with rvalue of existing pair") {
+            // Object-0 is moved due to reference collapsing rules. Object-1, as
+            // a reference, is neither copied nor moved.
+            REQUIRE_CALL(*mock_obj, move_construct(2, 0));
+
+            Pair result_pair{std::move(src_pair)};
+
+            THEN("the first value is equal to the moved value") {
+                CHECK(result_pair.first == src_pair.first);
+            }
+
+            THEN("the second value is a reference to the local variable") {
+                CHECK(result_pair.second == src_pair.second);
+                CHECK(&result_pair.second == &src_pair.second);
+            }
         }
     }
 }


### PR DESCRIPTION
Initialize `pair` type in exfs/utility library. For now, only contains member aliases, fields, and constructors.